### PR TITLE
:green_heart: fix(ci): fix Typst compilation and release workflow

### DIFF
--- a/.github/workflows/typst-compile.yml
+++ b/.github/workflows/typst-compile.yml
@@ -7,6 +7,12 @@ on:
   pull_request:
     paths: '**.typ'
   workflow_dispatch:
+    inputs:
+      create_release:
+        description: 'Create GitHub release with PDFs'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -26,57 +32,87 @@ jobs:
           sudo mv typst-x86_64-unknown-linux-musl/typst /usr/local/bin/
           typst --version
 
-      - name: Find all .typ files
+      - name: List all .typ files
         id: find-files
         run: |
-          # Find all .typ files and store as JSON array
-          FILES=$(find . -name "*.typ" -type f | jq -R -s -c 'split("\n") | map(select(length > 0))')
-          echo "files=$FILES" >> $GITHUB_OUTPUT
-          echo "Found files: $FILES"
+          echo "Found .typ files:"
+          find . -name "*.typ" -type f
 
       - name: Compile .typ files to PDF
         run: |
           mkdir -p output
+          FAILED=0
+          SUCCESS=0
           for file in $(find . -name "*.typ" -type f); do
             echo "Compiling $file..."
             filename=$(basename "$file" .typ)
-            typst compile "$file" --format pdf -o "output/${filename}.pdf" || echo "Failed to compile $file"
+            # Correct syntax: typst compile <INPUT> [OUTPUT]
+            if typst compile "$file" "output/${filename}.pdf" 2>&1; then
+              echo "✓ Successfully compiled: $file"
+              SUCCESS=$((SUCCESS + 1))
+            else
+              echo "✗ Failed to compile: $file"
+              FAILED=$((FAILED + 1))
+            fi
           done
-          ls -la output/
+          echo ""
+          echo "=== Compilation Summary ==="
+          echo "Successful: $SUCCESS"
+          echo "Failed: $FAILED"
+          ls -la output/ || echo "No PDFs generated"
+          if [ $FAILED -gt 0 ]; then
+            echo "::warning::Some Typst files failed to compile"
+          fi
 
-      - name: Create Release (if on main/master)
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+      - name: Create Release (manual only)
+        if: github.event_name == 'workflow_dispatch' && inputs.create_release == true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Generate version/tag from date and commit hash
-          VERSION="typst-$(date +%Y%m%d)-$(git rev-parse --short HEAD)"
-          TAG_NAME="v$VERSION"
-
-          # Check if tag exists
-          if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
-            echo "Tag $TAG_NAME already exists, skipping release creation"
-            # Update existing release
-            gh release delete "$TAG_NAME" -y || true
+          # Check if there are any PDFs to upload
+          if ! ls output/*.pdf 1> /dev/null 2>&1; then
+            echo "No PDFs found in output/ directory. Skipping release creation."
+            exit 1
           fi
 
-          # Create tag
-          git tag "$TAG_NAME"
-          git push origin "$TAG_NAME" || true
+          # Use a rolling 'latest' tag instead of creating new ones each time
+          TAG_NAME="typst-latest"
 
-          # Create release and upload PDFs
+          # Delete old release and tag if they exist
+          if gh release view "$TAG_NAME" >/dev/null 2>&1; then
+            echo "Deleting existing release: $TAG_NAME"
+            gh release delete "$TAG_NAME" -y || true
+          fi
+          if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
+            git tag -d "$TAG_NAME" || true
+            git push origin ":refs/tags/$TAG_NAME" || true
+          fi
+
+          # Create new tag
+          git tag "$TAG_NAME"
+          git push origin "$TAG_NAME"
+
+          # Create release with timestamp in notes
+          TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
           gh release create "$TAG_NAME" \
-            --title="Typst PDFs - $VERSION" \
+            --title="Typst PDFs - Built $TIMESTAMP" \
             --notes="Auto-generated PDFs from Typst sources
 
-          Built from commit: ${{ github.sha }}
+          Built from: ${{ github.sha }}
           Branch: ${{ github.ref_name }}
+          Timestamp: $TIMESTAMP
+
+          *This is a rolling release that updates with each manual run.*
           " \
             output/*.pdf
 
+          echo "Release created: $TAG_NAME"
+
       - name: Upload PDFs as artifacts
         uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: typst-pdfs
           path: output/*.pdf
+          if-no-files-found: warn
           retention-days: 30


### PR DESCRIPTION
## Summary

This PR fixes multiple issues in the Typst CI workflow that were causing compilation failures and release creation errors.

## Type of Change

- [x] `fix` - Bug fix or correction
- [ ] `feat` - New feature or implementation
- [ ] `docs` - Documentation only changes
- [ ] `style` - Code style changes (formatting, indentation)
- [ ] `refactor` - Code refactoring (no functional changes)
- [ ] `test` - Adding or updating tests
- [ ] `chore` - Build process, tooling, or dependency updates

## Files Changed

```bash
M .github/workflows/typst-compile.yml  # Fix Typst CLI syntax and release logic
```

## Fixes Applied

### 1. Fixed Typst CLI Syntax
| Before | After |
|--------|-------|
| `typst compile "\" --format pdf -o "output/\.pdf"` | `typst compile "\" "output/\.pdf"` |

The correct Typst CLI syntax is `typst compile <INPUT> [OUTPUT]`, not `--format pdf -o`.

### 2. Changed Release Strategy
- **Before**: Auto-created release on every push (too many tags)
- **After**: Manual release via `workflow_dispatch` with checkbox
- Uses rolling `typst-latest` tag instead of date-based tags

### 3. Added Better Error Handling
- Shows compilation summary (✓/✗ for each file)
- Counts successful/failed compilations
- `if-no-files-found: warn` prevents failure when no PDFs exist
- `if: always()` uploads artifacts even if compilation fails

### 4. Added Workflow Dispatch Input
``yaml
workflow_dispatch:
  inputs:
    create_release:
      description: 'Create GitHub release with PDFs'
      type: boolean
      default: false
``

## Testing

- [x] Typst CLI syntax verified locally (61KB PDF generated)
- [x] Workflow YAML syntax is valid
- [x] Handles missing PDFs gracefully

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes locally
- [x] I have updated the documentation (if applicable)

## Summary by Sourcery

Update Typst CI workflow to use correct CLI syntax, improve compilation reporting, and gate release creation behind a manual dispatch option using a rolling tag.

CI:
- Adjust Typst compilation step to use the correct CLI interface and provide a summary of successful and failed compilations.
- Change release creation to a manual workflow_dispatch option that publishes PDFs under a rolling typst-latest tag and cleans up any previous release.
- Improve artifact upload behavior so PDFs are always attempted to be uploaded and missing files only emit warnings.